### PR TITLE
Change the BBE URL links as /swan-lake/learn->/learn

### DIFF
--- a/xslt-ballerina/Package.md
+++ b/xslt-ballerina/Package.md
@@ -1,5 +1,5 @@
-## Module Overview
+## Package Overview
 
-This module provides a function to transform the XML content to another XML/HTML/plain text using XSL transformations.
+This package provides a function to transform the XML content to another XML/HTML/plain text using XSL transformations.
 
-For information on the operations, which you can perform with this module, see the below **Functions**. For examples on the usage of the operations, see the [XSLT Transformation Example](https://ballerina.io/swan-lake/learn/by-example/xslt-transformation.html).
+For information on the operations, which you can perform with this module, see the below **Functions**. For examples on the usage of the operations, see the [XSLT Transformation Example](https://ballerina.io/learn/by-example/xslt-transformation.html).


### PR DESCRIPTION
## Purpose
Due to the recent site changes of making swan lake default.