### PR TITLE
Upgrade Gradle to 9.5.1 and Ballerina Gradle plugin to 4.0.0

### DIFF
--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -16,6 +16,13 @@
  */
 
 import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.process.ExecOperations
+
+import javax.inject.Inject
+
+abstract class BallerinaExecHelper {
+    @Inject abstract ExecOperations getExecOperations()
+}
 
 plugins {
     id 'io.ballerina.plugin'
@@ -79,8 +86,9 @@ task updateTomlFiles {
 }
 
 task commitTomlFiles {
+    def execHelper = project.objects.newInstance(BallerinaExecHelper)
     doLast {
-        project.exec {
+        execHelper.execOperations.exec {
             ignoreExitValue true
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
                 commandLine 'cmd', '/c', "git commit -m \"[Automated] Update native jar versions in toml files\" Ballerina.toml Dependencies.toml"

--- a/build-config/checkstyle/build.gradle
+++ b/build-config/checkstyle/build.gradle
@@ -28,7 +28,7 @@ task downloadCheckstyleRuleFiles(type: Download) {
     ])
     overwrite false
     onlyIfNewer true
-    dest buildDir
+    dest layout.buildDirectory.get().asFile
 }
 
 jar {
@@ -39,10 +39,10 @@ clean {
     enabled = false
 }
 
-artifacts.add('default', file("$project.buildDir/checkstyle.xml")) {
+artifacts.add('default', layout.buildDirectory.file("checkstyle.xml")) {
     builtBy('downloadCheckstyleRuleFiles')
 }
 
-artifacts.add('default', file("$project.buildDir/suppressions.xml")) {
+artifacts.add('default', layout.buildDirectory.file("suppressions.xml")) {
     builtBy('downloadCheckstyleRuleFiles')
 }

--- a/build-config/checkstyle/build.gradle
+++ b/build-config/checkstyle/build.gradle
@@ -46,3 +46,5 @@ artifacts.add('default', layout.buildDirectory.file("checkstyle.xml")) {
 artifacts.add('default', layout.buildDirectory.file("suppressions.xml")) {
     builtBy('downloadCheckstyleRuleFiles')
 }
+
+test.mustRunAfter(downloadCheckstyleRuleFiles)

--- a/build-config/spotbugs-exclude.xml
+++ b/build-config/spotbugs-exclude.xml
@@ -16,9 +16,4 @@
   ~ under the License.
   -->
 <FindBugsFilter>
-    <!-- gradle9-rollout: temporary suppression pending review: surfaced by the SpotBugs plugin version bump needed for Gradle 9 / Java 25 support (see PR body) — pre-existing code, not introduced by this PR -->
-    <Match>
-        <Class name="io.ballerina.stdlib.xslt.XsltTransformer"/>
-        <Bug pattern="THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION"/>
-    </Match>
 </FindBugsFilter>

--- a/build-config/spotbugs-exclude.xml
+++ b/build-config/spotbugs-exclude.xml
@@ -16,4 +16,9 @@
   ~ under the License.
   -->
 <FindBugsFilter>
+    <!-- gradle9-rollout: temporary suppression pending review: surfaced by the SpotBugs plugin version bump needed for Gradle 9 / Java 25 support (see PR body) — pre-existing code, not introduced by this PR -->
+    <Match>
+        <Class name="io.ballerina.stdlib.xslt.XsltTransformer"/>
+        <Bug pattern="THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION"/>
+    </Match>
 </FindBugsFilter>

--- a/build.gradle
+++ b/build.gradle
@@ -96,6 +96,14 @@ release {
     }
 }
 
-tasks.named('build') {
-    dependsOn('xslt-ballerina:build')
+if (tasks.names.contains('build')) {
+    tasks.named('build') {
+        dependsOn('xslt-ballerina:build')
+
+    }
+} else {
+    tasks.register('build') {
+        dependsOn('xslt-ballerina:build')
+
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,9 @@ allprojects {
     version = project.version
 
     apply plugin: 'jacoco'
+    jacoco {
+        toolVersion = jacocoVersion
+    }
     apply plugin: 'maven-publish'
 
     repositories {
@@ -93,6 +96,6 @@ release {
     }
 }
 
-task build {
+tasks.named('build') {
     dependsOn('xslt-ballerina:build')
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,16 +2,17 @@ org.gradle.caching=true
 group=io.ballerina.stdlib
 version=2.9.2-SNAPSHOT
 ballerinaLangVersion=2201.12.0
+jacocoVersion=0.8.14
 
 jakartaActivationVersion=1.2.2
 axiomVersion=1.4.0
 slf4jVersion=1.7.30
 checkstylePluginVersion=10.12.0
-spotbugsPluginVersion=6.0.18
+spotbugsPluginVersion=6.5.1
 shadowJarPluginVersion=8.1.1
 downloadPluginVersion=5.4.0
-releasePluginVersion=2.8.0
-ballerinaGradlePluginVersion=2.3.0
+releasePluginVersion=3.1.0
+ballerinaGradlePluginVersion=4.0.0
 saxonHeVersion=11.4
 xmlResolverVersion=4.5.2
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,8 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionSha256Sum=bafc141b619ad6350fd975fc903156dd5c151998cc8b058e8c1044ab5f7b031f

--- a/native/build.gradle
+++ b/native/build.gradle
@@ -63,8 +63,8 @@ spotbugsMain {
     }
     reports {
         text.enabled = true
-            html.enabled true
-}
+        html.enabled true
+    }
 }
 
 spotbugsTest {

--- a/native/build.gradle
+++ b/native/build.gradle
@@ -56,14 +56,15 @@ spotbugsMain {
     def SpotBugsEffort = classLoader.findLoadedClass("com.github.spotbugs.snom.Effort")
     effort = SpotBugsEffort.MAX
     reportLevel = SpotBugsConfidence.LOW
-    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reportsDir = layout.buildDirectory.dir("reports/spotbugs")
     def excludeFile = file("${rootDir}/build-config/spotbugs-exclude.xml")
     if (excludeFile.exists()) {
         it.excludeFilter = excludeFile
     }
     reports {
         text.enabled = true
-    }
+            html.enabled true
+}
 }
 
 spotbugsTest {
@@ -73,9 +74,9 @@ spotbugsTest {
 task validateSpotbugs() {
     doLast {
         if (spotbugsMain.reports.size() > 0 &&
-                spotbugsMain.reports[0].destination.exists() &&
-                spotbugsMain.reports[0].destination.text.readLines().size() > 0) {
-            spotbugsMain.reports[0].destination?.eachLine {
+                spotbugsMain.reports.text.destination.exists() &&
+                spotbugsMain.reports.text.destination.text.readLines().size() > 0) {
+            spotbugsMain.reports.text.destination?.eachLine {
                 println 'Failure: ' + it
             }
             throw new GradleException("Spotbugs rule violations were found.");

--- a/native/src/main/java/io/ballerina/stdlib/xslt/XsltTransformer.java
+++ b/native/src/main/java/io/ballerina/stdlib/xslt/XsltTransformer.java
@@ -37,8 +37,10 @@ import org.apache.axiom.om.util.AXIOMUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.PrintStream;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
@@ -46,6 +48,7 @@ import java.nio.charset.StandardCharsets;
 import javax.xml.namespace.QName;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.stax.StAXSource;
@@ -121,7 +124,8 @@ public class XsltTransformer {
      * @param paramInput The input parameter map
      */
     private static void applyParameters(Transformer transformer,
-                                        BMap<BString, Object> paramInput) throws Exception {
+                                        BMap<BString, Object> paramInput) throws ParserConfigurationException,
+            SAXException, IOException {
         BIterator<?> iterator = paramInput.getIterator();
         while (iterator.hasNext()) {
             BArray next = (BArray) iterator.next();
@@ -153,7 +157,8 @@ public class XsltTransformer {
         return ErrorCreator.createDistinctError(XSLT_TRANSFORM_ERROR, getModule(), StringUtils.fromString(errMsg));
     }
 
-    public static Document convertToDocument(String xml) throws Exception {
+    public static Document convertToDocument(String xml) throws ParserConfigurationException, SAXException,
+            IOException {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         factory.setNamespaceAware(true);
         DocumentBuilder builder = factory.newDocumentBuilder();

--- a/settings.gradle
+++ b/settings.gradle
@@ -29,7 +29,7 @@ pluginManagement {
 }
 
 plugins {
-    id "com.gradle.enterprise" version "3.2"
+    id "com.gradle.develocity" version "3.19.2"
 }
 
 rootProject.name = 'xslt'
@@ -42,9 +42,9 @@ project(':checkstyle').projectDir = file("build-config${File.separator}checkstyl
 project(':xslt-native').projectDir = file('native')
 project(':xslt-ballerina').projectDir = file('ballerina')
 
-gradleEnterprise {
+develocity {
     buildScan {
-        termsOfServiceUrl = 'https://gradle.com/terms-of-service'
-        termsOfServiceAgree = 'yes'
+        termsOfUseUrl = 'https://gradle.com/help/legal-terms-of-use'
+        termsOfUseAgree = 'yes'
     }
 }


### PR DESCRIPTION
## Summary
- Upgrade the Gradle wrapper to 9.5.1 (with distribution checksum) and the Ballerina Gradle plugin to 4.0.0, needed for Java 21/25 compatibility.
- Fix Gradle 9 breakage: `project.exec` calls now use an injected `ExecOperations`, `com.gradle.enterprise` is migrated to `com.gradle.develocity`, any `task build {}` redefinition is replaced with `tasks.named('build')`, and checkstyle's `build.gradle` drops the deprecated `buildDir` property.
- Fix the SpotBugs finding the SpotBugs version bump surfaced: `XsltTransformer.convertToDocument` (and `applyParameters`, which calls it) declared `throws Exception`; narrowed to `ParserConfigurationException, SAXException, IOException`, the exceptions actually thrown by the JAXP `DocumentBuilderFactory`/`DocumentBuilder` calls involved.

## Test plan
- [x] `./gradlew clean build` passes locally on Gradle 9.5.1 with plugin 4.0.0
- [x] `./gradlew :xslt-native:spotbugsMain` passes with no suppressions needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Upgraded the Gradle wrapper to 9.5.1 with checksum verification.
- Updated the Ballerina Gradle plugin and related build dependencies for Java 21 and Java 25 compatibility.
- Migrated Gradle 9-incompatible APIs to `ExecOperations`, `layout.buildDirectory`, modern task registration, and Develocity configuration.
- Improved Checkstyle, JaCoCo, and SpotBugs task configuration.
- Replaced broad `throws Exception` declarations with specific checked exceptions in `XsltTransformer`.
- Added a temporary SpotBugs suppression for a native component finding.
- Confirmed that `./gradlew clean build` passes locally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->